### PR TITLE
Update to release 2.3.3.3

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  2.3.3.1.tar.gz: dcb42a1cd40038eb4e0d462e392ec923169363fc
+  yoshimi-2.3.3.3.tar.gz: b416c31c0938c6e0b1171e99c06ee36ee098f4a7

--- a/yoshimi-2.3.3.3-fix-build-with-fltk14.patch
+++ b/yoshimi-2.3.3.3-fix-build-with-fltk14.patch
@@ -1,0 +1,23 @@
+diff -rupN yoshimi-2.3.3.3.old/src/UI/MiscGui.cpp yoshimi-2.3.3.3/src/UI/MiscGui.cpp
+--- yoshimi-2.3.3.3.old/src/UI/MiscGui.cpp	2025-02-26 12:41:36.000000000 +0100
++++ yoshimi-2.3.3.3/src/UI/MiscGui.cpp	2025-05-07 21:00:53.620131663 +0200
+@@ -27,6 +27,7 @@
+ #include "MasterUI.h"
+ 
+ #include <FL/Fl.H>
++#include <FL/platform.H>
+ #include <FL/fl_draw.H>
+ 
+ #include <cairo.h>
+diff -rupN yoshimi-2.3.3.3.old/src/UI/WidgetPDial.cpp yoshimi-2.3.3.3/src/UI/WidgetPDial.cpp
+--- yoshimi-2.3.3.3.old/src/UI/WidgetPDial.cpp	2025-02-26 12:41:36.000000000 +0100
++++ yoshimi-2.3.3.3/src/UI/WidgetPDial.cpp	2025-05-07 21:01:26.514630908 +0200
+@@ -32,7 +32,7 @@
+ #include <FL/fl_draw.H>
+ #include <FL/Fl_Tooltip.H>
+ #include <FL/Fl_Group.H>
+-#include <FL/x.H>
++#include <FL/platform.H>
+ #include <cairo.h>
+ #include <cairo-xlib.h>
+ 

--- a/yoshimi.spec
+++ b/yoshimi.spec
@@ -1,74 +1,84 @@
-%define debug_package %{nil}
+%global	debug_package %{nil}
 
-Name:           yoshimi
-Summary:        ZynAddSubFX with improved RT capacities
-Version:        2.3.3.1
-Release:        2
-Source:         https://github.com/Yoshimi/yoshimi/archive/%{version}.tar.gz
-URL:            https://yoshimi.sourceforge.io/
-License:        GPLv2
+Summary:	ZynAddSubFX with improved RT capacities
+Name:		yoshimi
+Version:	2.3.3.3
+Release:	1
+Url:		https://yoshimi.sourceforge.io/
+License:	GPLv2
 Group:          Sound
-BuildRequires:  cmake 
-BuildRequires:  pkgconfig(alsa)
-BuildRequires:  pkgconfig(jack)
-BuildRequires:  zlib-devel
-BuildRequires:  pkgconfig(fftw3)
-BuildRequires:  pkgconfig(mxml)
-BuildRequires:  sndfile-devel 
-BuildRequires:  pkgconfig(fontconfig) 
-BuildRequires:  pkgconfig(glu)
-BuildRequires:  boost-devel
+Source0:	https://github.com/Yoshimi/yoshimi/archive/%{name}-%{version}.tar.gz
+Patch0:		yoshimi-2.3.3.3-fix-build-with-fltk14.patch
+BuildRequires:	cmake 
+BuildRequires:	desktop-file-utils
+BuildRequires:	fltk-fluid
+BuildRequires:	boost-devel
 BuildRequires:	fltk-devel 
-BuildRequires:	fltk-fluid 
-BuildRequires:  desktop-file-utils
+BuildRequires:	pkgconfig(alsa)
 BuildRequires:	pkgconfig(cairo)
-BuildRequires:  pkgconfig(lv2)
-BuildRequires:  pkgconfig(readline)
+BuildRequires:	pkgconfig(fftw3)
+BuildRequires:	pkgconfig(fontconfig) 
+BuildRequires:	pkgconfig(glu)
+BuildRequires:	pkgconfig(jack)
+BuildRequires:	pkgconfig(lv2)
+# mxml4 not supported yet
+BuildRequires:	pkgconfig(mxml)
+BuildRequires:	pkgconfig(readline)
+BuildRequires:	pkgconfig(sndfile)
+BuildRequires:	pkgconfig(zlib)
 
 %description
 Yoshimi is the legendary and powerful ZynAddSubFX multitimbral standalone
 synthesizer, but with improved realtime capacities. Yoshimi can use
-either ALSA or JACK for both Audio and MIDI, the default now being JACK
+either ALSA or JACK for both Audio and MIDI, the default now being JACK.
+
+%files
+%doc %{_datadir}/doc/%{name}/
+%{_bindir}/%{name}
+%{_libdir}/lv2/%{name}.lv2/
+%dir %{_datadir}/%{name}
+%{_datadir}/%{name}/*
+%{_datadir}/applications/%{name}.desktop
+%{_datadir}/metainfo/%{name}.metainfo.xml
+%{_datadir}/pixmaps/%{name}.png
+%{_iconsdir}/hicolor/*/apps/%{name}.*
+%{_iconsdir}/hicolor/scalable/apps/%{name}_alt.svg
+%{_mandir}/man1/%{name}.1.*
+
+#-----------------------------------------------------------------------------
 
 %prep
-%setup -q
+%autosetup -p1
+
 
 %build
 cd src
 %cmake  \
-        -DCMAKE_CXX_FLAGS="${RPM_OPT_FLAGS} -fPIC" \
-        -DFLTK_INCLUDE_DIR=%{_includedir}/Fl \
-        -DCMAKE_INSTALL_PREFIX=%{_prefix}
+	-DCMAKE_CXX_FLAGS="%{optflags} -fPIC" \
+	-DFLTK_INCLUDE_DIR=%{_includedir}/FL \
+	-DCMAKE_INSTALL_PREFIX=%{_prefix}
 %make_build
+
 
 %install
 cd src
 %make_install -C build
 
-rm -f %{buildroot}%{_datadir}/%{name}/banks/chip/.bankdir
+# Drop hidden files
+rm -f %{buildroot}%{_datadir}/%{name}/banks/*/.bankdir
+
+# We pick the example files as doc: avoid a zillion of "files-duplicate" rpmllint warnings
+rm -rf %{buildroot}%{_datadir}/%{name}/examples/*
+rm -rf %{buildroot}%{_datadir}/doc/%{name}/Yoshimi_License_History.txt
+
+# Fix perms
 chmod -R 755 %{buildroot}%{_datadir}/%{name}/banks
 chmod -R 755 %{buildroot}%{_datadir}/%{name}/presets
 chmod a-X %{buildroot}%{_datadir}/%{name}/banks/*/*
 chmod a-X %{buildroot}%{_datadir}/%{name}/presets/*
 
-desktop-file-install \
-    --remove-key="Version" \
-    --add-category="X-MandrivaLinux-Sound" \
-    --dir %{buildroot}%{_datadir}/applications \
-%{buildroot}%{_datadir}/applications/%{name}.desktop
-
-%clean
-
-%files
-
-%dir %{_datadir}/%{name}
-%doc %{_datadir}/doc/yoshimi/
-%{_bindir}/%{name}
-%{_libdir}/lv2/yoshimi.lv2/
-%{_datadir}/%{name}/*
-%{_datadir}/applications/%{name}.desktop
-%{_datadir}/metainfo/yoshimi.metainfo.xml
-%{_datadir}/pixmaps/%{name}.png
-%{_iconsdir}/hicolor/*/apps/yoshimi.*
-%{_iconsdir}/hicolor/scalable/apps/yoshimi_alt.svg
-%{_mandir}/man1/yoshimi.1.*
+# Fix .desktop file
+desktop-file-edit \
+	--remove-key="Version" \
+	--add-category="X-OpenMandriva-Sound" \
+	%{buildroot}%{_datadir}/applications/%{name}.desktop


### PR DESCRIPTION
Our yoshimi  release is a few months old and is not buildable against fltk 1.4.x that we have in Cooker and Rolling. Bring it to the latest 2.3.3.3 release and add a patch to use new fltk.